### PR TITLE
fix: removing unknown Docker --verbose parameter

### DIFF
--- a/rust/Makefile.jinja
+++ b/rust/Makefile.jinja
@@ -77,7 +77,7 @@ publish-crate:
 .PHONY: dogfood-docker
 dogfood-docker: release
 	docker build --build-arg TARGET=$(MUSL_TARGET) --tag {{ project_name }} --file Dockerfile .
-	docker run --rm --volume $(PWD):/workspace --workdir /workspace --env HOME=/github/home --env GITHUB_ACTIONS=true --env CI=true --verbose {{ project_name }}
+	docker run --rm --volume $(PWD):/workspace --workdir /workspace --env HOME=/github/home --env GITHUB_ACTIONS=true --env CI=true {{ project_name }}
 
 .PHONY: publish-docker
 publish-docker:


### PR DESCRIPTION
```
docker run --rm --volume /home/runner/work/consistent_whitespace/consistent_whitespace:/workspace --workdir /workspace --env HOME=/github/home --env GITHUB_ACTIONS=true --env CI=true --verbose consistent_whitespace
unknown flag: --verbose
```