### PR TITLE
ci: Renovate managing GitHub Actions .yml.jinja workflows

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -16,6 +16,17 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
+        "/(^|/)\\.github/workflows/[^/]+\\.ya?ml\\.jinja$/"
+      ],
+      "matchStrings": [
+        "uses:\\s+(?<depName>[\\w.-]+/[\\w.-]+)@(?<currentDigest>[a-f0-9]{40})\\s+#\\s+(?<currentValue>v?[\\d.]+)"
+      ],
+      "datasourceTemplate": "github-tags",
+      "versioningTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
         "/(^|/|\\.)Dockerfile$/",
         "/(^|/)Dockerfile[^/]*$/"
       ],


### PR DESCRIPTION
Renovate's built-in github-actions manager only matches *.yml/*.yaml
files and skips rust/.github/workflows/dogfood.yml.jinja, so its pinned
actions (actions/checkout, cachix/install-nix-action) drifted behind the
rest of the repo.